### PR TITLE
Making registry package more usable for external projects

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+package main
 
 import (
 	"log"

--- a/main.go
+++ b/main.go
@@ -1,4 +1,3 @@
-package main
 
 import (
 	"log"

--- a/registry/API.go
+++ b/registry/API.go
@@ -37,10 +37,12 @@ func NewAPI(host string) *API {
 	}
 }
 
+// SetClient changes the http.Client used for http requests.
 func (a *API) SetClient(client *http.Client) {
 	a.client = *client
 }
 
+// SetPageSize overrides the default page size used by the API.
 func (a *API) SetPageSize(size int) {
 	a.pageSize = size
 }
@@ -134,6 +136,7 @@ func (a *API) GetManifestCreated(repository string, tag string) (time.Time, erro
 	return t, err
 }
 
+// GetManifestDigestAndCreated returns the digest and creation time.
 func (a *API) GetManifestDigestAndCreated(repository string, tag string) (string, time.Time, error) {
 	resp, err := a.doRequest("GET", "/v2/"+repository+"/manifests/"+tag, manifestV1)
 	if err != nil {

--- a/registry/API.go
+++ b/registry/API.go
@@ -37,8 +37,8 @@ func NewAPI(host string) *API {
 	}
 }
 
-// SetClient changes the http.Client used for http requests.
-func (a *API) SetClient(client *http.Client) {
+// SetHTTPClient changes the http.Client used for http requests.
+func (a *API) SetHTTPClient(client *http.Client) {
 	a.client = *client
 }
 


### PR DESCRIPTION
This adds a SetClient() method to swap out the http.Client used, and a SetPageSize method to allow overriding the default page size for the registry.  